### PR TITLE
fix: remove postfix of make target call in pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Build SDK
-        run: make build_${{ matrix.language }}_sdk
+        run: make build_${{ matrix.language }}
       - name: Check worktree clean
         run: |
           git update-index -q --refresh


### PR DESCRIPTION
Hi @ringods,

This PR removes the postfix of make target call in pipeline