### PR TITLE
fix: change go module path in sdk module to pulumiverse

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-exoscale/sdk
+module github.com/pulumiverse/pulumi-exoscale/sdk
 
 go 1.19
 


### PR DESCRIPTION
This PR change Go module path in sdk module to pulumiverse