### PR TITLE
feat: remove LogoURL to use default logos from pulumi-hugo

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -65,7 +65,7 @@ func Provider() tfbridge.ProviderInfo {
 		//
 		// You may host a logo on a domain you control or add an SVG logo for your package
 		// in your repository and use the raw content URL for that file as your logo URL.
-		LogoURL: "https://avatars3.githubusercontent.com/exoscale",
+		LogoURL: "",
 		// PluginDownloadURL is an optional URL used to download the Provider
 		// for use in Pulumi programs
 		// e.g https://github.com/org/pulumi-provider-name/releases/


### PR DESCRIPTION
Hi,

This PR removes the LogoURL to use the default logos from the pulumi-hugo template

Relates to -> https://github.com/pulumi/pulumi-hugo/pull/2176